### PR TITLE
Added option to create role/group and reference resources within module and other logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_cloudtrail" "default" {
   is_multi_region_trail         = true
   include_global_service_events = var.include_global_service_events
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn != "" ? var.cloud_watch_logs_role_arn : aws_iam_role.cloudtrail_cloudwatch_role[0].arn
-  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
+  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn != "" ? var.cloud_watch_logs_group_arn : "${aws_cloudwatch_log_group.cloudtrail[0].arn}:*"
   kms_key_id                    = aws_kms_key.cloudtrail.arn
   is_organization_trail         = var.is_organization_trail
   tags                          = module.labels.tags
@@ -81,6 +81,7 @@ resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
   assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 resource "aws_cloudwatch_log_group" "cloudtrail" {
+  count             = var.cloud_watch_logs_group_arn == "" ? 1 : 0
   name              = var.cloudwatch_log_group_name
   retention_in_days = var.log_retention_days
   kms_key_id        = aws_kms_key.cloudtrail.arn


### PR DESCRIPTION
## what
Hi Clouddrove team,

I have forked your "clouddrove/cloudtrail/aws" repo.

Essentially, although the following reoruces are created, they weren’t referenced inside the module:
- var.cloud_watch_logs_role_arn
- var.cloud_watch_logs_group_arn

## why
 Further to this:
- on line 98 of main.tf the var.cloud_watch_logs_role_arn is hardcoded to eu-west-1.  
- When the role is linked it fails in my region
- The cloudwatch log section had to be manually completed via the console. This created a new policy with the correct region.
 resources = ["arn:${data.aws_partition.current.partition}:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:log-group:cloudwatch-log-group:*"]

## The code has been updated to include the following logic:
- If the above-mentioned variables are supplied, the module will use them and NOT create the ROLE and Cloudwatch Log group
- If not supplied, the module now correctly creates the role and associated policy in the correct region. It links correctly in the Cloudtrails Cloudwatch section to this role and group.