### PR TITLE
feat: s3_key_prefix attribute for cloudtrail

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ resource "aws_cloudtrail" "default" {
   name                          = module.labels.id
   enable_logging                = var.enable_logging
   s3_bucket_name                = var.s3_bucket_name
+  s3_key_prefix                 = var.s3_key_prefix
   enable_log_file_validation    = var.enable_log_file_validation
   is_multi_region_trail         = var.is_multi_region_trail
   include_global_service_events = var.include_global_service_events

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,12 @@ variable "s3_bucket_name" {
   description = "S3 bucket name for CloudTrail log."
 }
 
+variable "s3_key_prefix" {
+  type        = string
+  default     = ""
+  description = "(Optional) S3 key prefix that follows the name of the bucket you have designated for log file delivery."
+}
+
 variable "cloud_watch_logs_role_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
s3_key_prefix attribute.
S3 key prefix that follows the name of the bucket you have designated for log file delivery.