### PR TITLE
Fix: 🐛 Fixed cloudtrail log group creation issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_cloudtrail" "default" {
   is_multi_region_trail         = var.is_multi_region_trail
   include_global_service_events = var.include_global_service_events
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
-  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
+  cloud_watch_logs_group_arn    = format("%s:*", var.cloud_watch_logs_group_arn)
   kms_key_id                    = join("", aws_kms_key.cloudtrail[*].arn) # aws_kms_key.cloudtrail[0].arn != null ? aws_kms_key.cloudtrail[0].arn : null
   is_organization_trail         = var.is_organization_trail
   tags                          = module.labels.tags


### PR DESCRIPTION
## what
* Fixed cloudtrail creation issue because of Cloudwatch log group format was not correct.

## why
* Passed CloudWatch log group was not correct, it was throwing error said "CloudTrail cannot validate the specified log group ARN."

## Screenshots
![image](https://github.com/clouddrove/terraform-aws-cloudtrail/assets/115100281/7044744e-590f-4add-b838-133e4af5d47a)

**We have to create new release of this module after merging this PR, This will used in i-sec project**