### PR TITLE
Fix handling of default (empty) `cloud_watch_logs_group_arn`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_cloudtrail" "default" {
   is_multi_region_trail         = var.is_multi_region_trail
   include_global_service_events = var.include_global_service_events
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
-  cloud_watch_logs_group_arn    = format("%s:*", var.cloud_watch_logs_group_arn)
+  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn != "" ? format("%s:*", var.cloud_watch_logs_group_arn) : ""
   kms_key_id                    = join("", aws_kms_key.cloudtrail[*].arn) # aws_kms_key.cloudtrail[0].arn != null ? aws_kms_key.cloudtrail[0].arn : null
   is_organization_trail         = var.is_organization_trail
   tags                          = module.labels.tags


### PR DESCRIPTION
## what
* The default (empty string) `cloud_watch_logs_group_arn` should NOT have `:*` appended to it.

## why
* The `':*'` value causes the following error:
```
│ Error: "cloud_watch_logs_group_arn" (:*) is an invalid ARN: arn: invalid prefix
│ 
│   with module.cloudtrail.aws_cloudtrail.default[0],
│   on .terraform/modules/cloudtrail/main.tf line 35, in resource "aws_cloudtrail" "default":
│   35:   cloud_watch_logs_group_arn    = format("%s:*", var.cloud_watch_logs_group_arn)
│ 
```


## references
* This is a fix to the change introduced in: https://github.com/clouddrove/terraform-aws-cloudtrail-baseline/pull/34
* `hashicorp/aws` provider document asserting that `cloud_watch_logs_group_arn` is optional: https://registry.terraform.io/providers/hashicorp/aws/5.21.0/docs/resources/cloudtrail#cloud_watch_logs_group_arn